### PR TITLE
statflo-756 add secrets pass-through input; 2nd try

### DIFF
--- a/.github/workflows/docker-pr.yaml
+++ b/.github/workflows/docker-pr.yaml
@@ -2,14 +2,14 @@ name: Docker - PR
 
 on:
   workflow_call:
+    secrets:
+      GIT_AUTH_TOKEN:
+        required: false
     inputs:
       service_path:
         type: string
         required: false
         default: '.'
-      secrets:
-        type: string
-        required: false
 
 jobs:
   build:
@@ -43,4 +43,5 @@ jobs:
           push: false
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
-          secrets: ${{ inputs.secrets }}
+          secrets:
+            GIT_AUTH_TOKEN: ${{ secrets.GIT_AUTH_TOKEN }}


### PR DESCRIPTION
We want to allow docker-pr to run with statflo-development user PAT.